### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "java10"
+run = "mvnw spring-boot:run"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# spring5webapp
+# spring5webapp [![Run on Repl.it](https://repl.it/badge/github/ravi2519/spring5webapp)](https://repl.it/github/ravi2519/spring5webapp)
 
 Started with a Spring Boot Project with Web, JPA and H2
 


### PR DESCRIPTION
This pull request configures this repository to be run on Repl.it.      It adds a `.replit` configuration file and a Repl.it badge to the `README`.
     You can read more about running repos on Repl.it [here](https://docs.repl.it/repls/dot-replit), or view the Repl [here](https://repl.it/@ravi2519/spring5webapp).